### PR TITLE
fix(DO-1549): fixing corner case

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,10 +27,19 @@ function run_sledger() {
    exit $result
 }
 
+function wait_for_istio() {
+   while ! curl -fsI http://localhost:15021/healthz/ready
+   do
+      echo "Waiting for Istio sidecar proxy..."
+      sleep 1
+   done
+}
+
 if [[ $# -gt 0 ]]; then
    exec $@
 else
    wait_for_db
+   wait_for_istio
    run_sledger
 fi
 


### PR DESCRIPTION
Under certain conditions the sledger job will complete execution completely prior to the Istio sidecar proxy starting.  In this case, the Istio sidecar proxy will still persist even after the job finishes due to the curl kill command being executed prior to the sidecar being up.

This change causes the job to wait for the sidecar to come up prior to executing.

Jira: https://motorefi.atlassian.net/browse/DO-1549