### PR TITLE
Publish to GAR

### DIFF
--- a/ci/charts/sledger/Chart.yaml
+++ b/ci/charts/sledger/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ci/workflows/helm-release.yaml
+++ b/ci/workflows/helm-release.yaml
@@ -48,7 +48,7 @@ spec:
               spec:
                 serviceAccountName: shared-svcs-1-argo-workflows-sa
                 workflowTemplateRef:
-                  name: helm-release-v2-0-0
+                  name: helm-release-v4-0-0
                 arguments:
                   parameters:
                     - name: semver


### PR DESCRIPTION
This PR updates the sensor so that the workflow publishes the helm chart to the GAR instead of Nexus (the docker image was already done).

This PR also bumps the chart version so that a release can be done post merge.